### PR TITLE
Remove pass by reference parameter

### DIFF
--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -19,7 +19,7 @@ int Response::apiPostData(cpr::Header &headers, string &postData, string &postRe
 }
 
 // Send job confirmation information back to bakup
-int Response::postJobConfirmation(string &postData, string &postResponse)
+int Response::postJobConfirmation(string &postData)
 {
     // Add the authorisation token to the headers
     cpr::Header headers = cpr::Header{{"Authorization", this->authToken}, {"Content-Type", "text/json"}};

--- a/src/Response.h
+++ b/src/Response.h
@@ -31,7 +31,7 @@ class Response
         Response(string url, string authToken);
 
         // Send job confirmation information back to bakup
-        int postJobConfirmation(string &postData, string &postResponse);
+        int postJobConfirmation(string &postData);
 };
 
 #endif //BAKUP_AGENT_RESPONSE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,9 +128,8 @@ int main(int argc, char *argv[])
             const string jobConfirmationUrl = agent.getBakupJobConfirmationURL();
 
             // Send the job response to Bakup
-            string postJobResponse;
             Response response(jobConfirmationUrl, agent.getAuthToken());
-            int jobConfStatus = response.postJobConfirmation(jobStatusString, postJobResponse);
+            int jobConfStatus = response.postJobConfirmation(jobStatusString);
 
             // Print the outcome of the job response
             debug.print("Job confirmation response: " + to_string(jobConfStatus));

--- a/tests/ResponseTest.cpp
+++ b/tests/ResponseTest.cpp
@@ -17,9 +17,8 @@ class ResponseTest : public ::testing::Test
 TEST_F(ResponseTest, PostJobConfirmation)
 {
     string jobStatus = "[{\"test\": true}]";
-    string jobResponse;
     Response response(this->agent.getBakupJobConfirmationURL(), this->agent.getAuthToken());
-    int statusCode = response.postJobConfirmation(jobStatus, jobResponse);
+    int statusCode = response.postJobConfirmation(jobStatus);
     ASSERT_GE(statusCode, 200);
     ASSERT_LT(statusCode, 500);
 }


### PR DESCRIPTION
The postResponse parameter used to be used to store the response from the server, but since it was converted in to a class, the response is stored elsewhere