### PR TITLE
Fix formatting of datetime string

### DIFF
--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -16,16 +16,22 @@ Debug::Debug(const Debug &obj)
 
 string Debug::getDateTime()
 {
+    // Get the current time
     time_t rawTime;
     time(&rawTime);
-    struct tm* fullTime = gmtime(&rawTime);
 
-    return to_string(1900 + fullTime->tm_year) + "-"
-            + to_string(fullTime->tm_mon) + "-"
-            + to_string(fullTime->tm_mday) + "T"
-            + to_string(fullTime->tm_hour) + ":"
-            + to_string(fullTime->tm_min) + ":"
-            + to_string(fullTime->tm_sec);
+    // Create the char array to hold the time string
+    char timeString[100];
+
+    // If the datetime is created successfully, return it
+    if (strftime(timeString, sizeof(timeString), "%Y-%m-%dT%H:%M:%S", localtime(&rawTime)))
+    {
+        return string(timeString);
+    }
+    else // if not, return failed
+    {
+        return "FAILED TO GET TIME";
+    }
 }
 
 void Debug::info(string infoString)

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -24,7 +24,7 @@ string Debug::getDateTime()
     char timeString[100];
 
     // If the datetime is created successfully, return it
-    if (strftime(timeString, sizeof(timeString), "%Y-%m-%dT%H:%M:%S", localtime(&rawTime)))
+    if(strftime(timeString, sizeof(timeString), "%Y-%m-%d %H:%M:%S", localtime(&rawTime)))
     {
         return string(timeString);
     }


### PR DESCRIPTION
Seconds 1-9 did not display 0 beforehand (2 vs. 02), making output out of line