### PR TITLE
Simultaneous file descriptor pipes to forked child with access to bash shell for persistent commands 

### DIFF
--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -1,12 +1,14 @@
-#include <csignal>
 #include "Command.h"
 
 Command::Command(Debug &debug) : debug(ref(debug)) {}
 
 Command::~Command()
 {
-    // Kill the child upon destruction
-    kill(this->pid, SIGKILL);
+    if(this->pid > -1)
+    {
+        // Kill the child upon destruction
+        kill(this->pid, SIGKILL);
+    }
 }
 
 string Command::generateDelimiter()

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -79,26 +79,27 @@ bool Command::setupEnvironment(string bashTestCommand)
     this->out = this->outPipeFD[1];
     this->in = this->inPipeFD[0];
 
+    // Wait for the child to change state
     int status;
     pid_t result = waitpid(this->pid, &status, WNOHANG);
-    if (result == 0)
+    if (result == 0) // If the child is alive
     {
-        // Child is alive, check that the bash shell is setup correctly
+        // Check that the bash shell is setup correctly by running a command
         auto [output, exitStatus] = runCommand(bashTestCommand);
-        if(exitStatus != EXIT_SUCCESS)
+        if(exitStatus != EXIT_SUCCESS) // If failed
         {
             return false;
         }
-        else
+        else // Else, successful
         {
             return true;
         }
     }
-    else if (result == -1)
+    else if (result == -1) // Else, there was an error returned by waitpid
     {
         return false;
     }
-    else
+    else // Else, the child died
     {
         return false;
     }
@@ -122,7 +123,7 @@ std::pair<string, exit_status_t> Command::runCommand(string cmd)
     if(len <= 0)
     {
         return {{}, ES_WRITE_FAILED};
-    };
+    }
 
     // Wipe command and use it to collect all read data
     cmd.resize(0);

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -1,49 +1,147 @@
+#include <csignal>
 #include "Command.h"
 
-int Command::process()
+Command::Command(Debug &debug) : debug(ref(debug)) {}
+
+Command::~Command()
 {
-    // Redirect stderr to std out
-    this->command = this->command + " 2>&1";
+    // Kill the child upon destruction
+    kill(this->pid, SIGKILL);
+}
 
-    // An array to hold the output of the stream from the command process
-    array<char, 128> buffer{};
+string Command::generateDelimiter()
+{
+    thread_local std::mt19937 prng(std::random_device{}());
+    thread_local std::uniform_int_distribution dist('a', 'z');
+    thread_local auto gen = [&]() { return dist(prng); };
 
-    // Open a stream in read mode using the supplied command
-    auto pipe = popen(command.c_str(), "r");
+    std::string delimiter(128, 0);
+    std::generate(delimiter.begin(), delimiter.end(), gen);
 
-    // If the stream fails to open, return an error
-    if(!pipe)
+    return delimiter;
+}
+
+/*
+ * Must only be ran once per Command object.
+ * This will setup a child process and establish the pipes for reading and writing to it
+ */
+bool Command::setupEnvironment()
+{
+    // Create a read and write pipe for communication with the child process
+    pipe(this->inPipeFD);
+    pipe(this->outPipeFD);
+
+    // Set read pipes to non-blocking and handle waiting in the runCommand method
+    fcntl(this->inPipeFD[0], F_SETFL, fcntl(this->inPipeFD[0], F_GETFL) & O_NONBLOCK);
+    fcntl(this->inPipeFD[1], F_SETFL, fcntl(this->inPipeFD[1], F_GETFL) & O_NONBLOCK);
+
+    // Create a child to run the job commands in
+    this->pid = fork();
+
+    // Check child was made
+    if(this->pid < 0)
     {
-        this->output = "Popen failed to open a stream";
-        return -1;
+        // Print an error to console
+        this->debug.error("Could not open a child process to run the job");
+
+        // Return error to caller
+        return false;
     }
-    else // Otherwise, the stream can be used successfully
+    else if(this->pid == 0)
     {
-        // Read from stream until EOF is found
-        while(!feof(pipe))
+        // Close STDIN and replace it with outPipeFD read end
+        dup2(this->outPipeFD[0], STDIN_FILENO);
+        close(this->outPipeFD[0]); // not needed anymore
+
+        // Close STDOUT and replace it with inPipe read end
+        dup2(this->inPipeFD[1], STDOUT_FILENO);
+        close(this->inPipeFD[1]); // not needed anymore
+
+        // Start a bash shell
+        execl("/bin/bash", "bash", nullptr);
+
+        // This statement will only be reached if the execl fails
+        return false;
+    }
+    else
+    {
+        // Close the read end of the write pipe
+        close(this->outPipeFD[0]);
+
+        // Close the write end of the read pipe
+        close(this->inPipeFD[1]);
+    }
+
+    // For convenience and ease of maintainability, set the parent's in and out pipes
+    this->out = this->outPipeFD[1];
+    this->in = this->inPipeFD[0];
+
+    return true;
+}
+
+std::pair<string, exit_status_t> Command::runCommand(string cmd)
+{
+    // Buffer size for things being sent through pipes
+    constexpr size_t BufSize = 1024;
+
+    // a string that is unlikely to show up in the output:
+    const std::string delimiter = generateDelimiter() + "\n";
+
+    // Add an echo of the status of the command that was ran
+    cmd += " 2>&1\necho -e $?\"\\n\"" + delimiter;
+
+    // Send the command to the child process
+    auto len = write(this->out, cmd.c_str(), cmd.size());
+
+    // If the length is 0 or less, the pipe couldn't be written to
+    if(len <= 0)
+    {
+        return {{}, ES_WRITE_FAILED};
+    };
+
+    // Wipe command and use it to collect all read data
+    cmd.resize(0);
+
+    // Use buffer to store each line being read
+    std::string buffer(BufSize, 0);
+
+    // Loop and read all data until the delimiter is found
+    fd_set read_set{};
+    FD_SET(this->in, &read_set);
+    while(true) {
+        // Wait until something happens on the pipe
+        select(this->in + 1, &read_set, nullptr, nullptr, nullptr);
+
+        // If the read failed on the pipe
+        if((len = read(this->in, buffer.data(), buffer.size())) <= 0)
         {
-            // If the read data is not null
-            if(fgets(buffer.data(), 128, pipe) != nullptr)
-            {
-                // Write the line of output to the output string
-                this->output += buffer.data();
-            }
+            // Set an error code and break reading
+            cmd += "\n" + std::to_string(ES_READ_FAILED) + "\n" + delimiter;
+            break;
+        }
+
+        // Append what was read to cmd
+        cmd.append(buffer.begin(), buffer.begin() + len);
+
+        // If the delimiter was found, break
+        if(cmd.size() >= delimiter.size() && cmd.substr(cmd.size() - delimiter.size()) == delimiter)
+        {
+            break;
         }
     }
 
-    // Close the pipe and read the status code
-    auto statusCode = pclose(pipe);
+    // Remove the delimiter from the command output and trailing newline
+    cmd.resize(cmd.size() - (delimiter.size() + 1));
 
-    // Return the status code of the command
-    return statusCode;
-}
+    // Get the position of the newline that is in front of the exit status
+    int newLinePosition = cmd.rfind('\n');
 
-Command::Command(string &command)
-{
-    this->command = command;
-}
+    // Extract the exit status and convert to int
+    exit_status_t exitStatus = static_cast<exit_status_t>(stoi(cmd.substr(newLinePosition + 1, cmd.size())));
 
-string Command::getOutput()
-{
-    return this->output;
+    // Remove the exit status from the command output
+    string output = cmd.substr(0, newLinePosition);
+
+    // Return the pair
+    return {output, exitStatus};
 }

--- a/src/Command.h
+++ b/src/Command.h
@@ -42,7 +42,7 @@ class Command
         int in;
 
         // The process id of the child to be opened
-        pid_t pid;
+        pid_t pid = -1;
 
     public:
         // Constructor

--- a/src/Command.h
+++ b/src/Command.h
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 #include <fcntl.h>
 #include <csignal>
+#include <wait.h>
 
 using namespace std;
 
@@ -44,9 +45,12 @@ class Command
         // The process id of the child to be opened
         pid_t pid = -1;
 
+        // Store executable to run for bash shell, only for testing
+        string shell = "/bin/bash";
+
     public:
         // Constructor
-        Command(Debug &debug);
+        Command(Debug &debug, string shell = "/bin/bash");
 
         // Destructor
         ~Command();
@@ -55,10 +59,13 @@ class Command
         string generateDelimiter();
 
         // Setup the child process and pipes
-        bool setupEnvironment();
+        bool setupEnvironment(string bashTestCommand = "echo");
 
         // Send a command to the bash process and return the output and an exit status
         std::pair<string, exit_status_t> runCommand(string command);
+
+        // Setter for shell variable
+        bool setShell(string &shell);
 };
 
 #endif //BAKUP_AGENT_COMMAND_H

--- a/src/Command.h
+++ b/src/Command.h
@@ -1,33 +1,64 @@
 #ifndef BAKUP_AGENT_COMMAND_H
 #define BAKUP_AGENT_COMMAND_H
 
+#include <Debug.h>
+#include <ResponseBuilder.h>
+
 #include <string>
 #include <array>
 #include <unistd.h>
 #include <cstdio>
 #include <cstdlib>
 #include <utility>
+#include <algorithm>
+#include <iostream>
+#include <random>
+#include <sstream>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <csignal>
 
 using namespace std;
+
+// Stores the exit code from a job or these error codes
+enum exit_status_t {
+    ES_WRITE_FAILED = 256,
+    ES_READ_FAILED,
+    ES_EXIT_STATUS_NOT_FOUND
+};
 
 class Command
 {
     private:
-        // The command being processed
-        string command;
+        // Debug class for output
+        Debug debug;
 
-        // Program output
-        string output;
+        // Store file descriptors that will be used throughout the jobs life
+        int inPipeFD[2];
+        int outPipeFD[2];
+
+        // For convenience of reading which are the parent pipes for writing and reading
+        int out;
+        int in;
+
+        // The process id of the child to be opened
+        pid_t pid;
 
     public:
         // Constructor
-        Command(string &command);
+        Command(Debug &debug);
 
-        // Process a command
-        int process();
+        // Destructor
+        ~Command();
 
-        // Get the output from the command
-        string getOutput();
+        // Generate delimiter strings to append to command to know when they're finished
+        string generateDelimiter();
+
+        // Setup the child process and pipes
+        bool setupEnvironment();
+
+        // Send a command to the bash process and return the output and an exit status
+        std::pair<string, exit_status_t> runCommand(string command);
 };
 
 #endif //BAKUP_AGENT_COMMAND_H

--- a/src/Job.cpp
+++ b/src/Job.cpp
@@ -14,7 +14,7 @@ Job::Job(Debug &debug, command_t &job, string baseUrl, string clientId, string a
     }
 }
 
-bool Job::process(bool autoReportResults)
+int Job::process(bool autoReportResults)
 {
     // Start a new command instance
     Command command(debug);
@@ -42,7 +42,7 @@ bool Job::process(bool autoReportResults)
         // Kill the bash child
         command.~Command();
 
-        return false;
+        return exitStatus;
     }
 
     if(!checkShellReady(command, 1, 2))
@@ -64,7 +64,7 @@ bool Job::process(bool autoReportResults)
         // Kill the bash child
         command.~Command();
 
-        return false;
+        return exitStatus;
     }
 
     // Check the job vector isn't empty
@@ -161,7 +161,7 @@ bool Job::process(bool autoReportResults)
     // Kill the bash child
     command.~Command();
 
-    return true;
+    return exitStatus;
 }
 
 bool Job::reportResults(int retryCounter, int maxRetry)

--- a/src/Job.h
+++ b/src/Job.h
@@ -41,16 +41,13 @@ class Job
         Job(Debug &debug, command_t &job, string baseUrl, string clientId, string apiToken, bool autoExecute = true);
 
         // Process the commands in the job
-        int process(bool autoReportResults = true);
+        int process(bool autoReportResults = true, string shell = "/bin/bash");
 
         // Report the results to Bakup
         bool reportResults(int retryCounter, int maxRetry);
 
         // Handle printing errors
         bool handleError(string &httpResponse, cpr::Error error);
-
-        // Check that the child shell is writable
-        bool checkShellReady(Command &command, int retryAmount, int secondsToWait);
 };
 
 

--- a/src/Job.h
+++ b/src/Job.h
@@ -41,13 +41,16 @@ class Job
         Job(Debug &debug, command_t &job, string baseUrl, string clientId, string apiToken, bool autoExecute = true);
 
         // Process the commands in the job
-        int process(bool autoReportResults = true);
+        bool process(bool autoReportResults = true);
 
         // Report the results to Bakup
         bool reportResults(int retryCounter, int maxRetry);
 
         // Handle printing errors
         bool handleError(string &httpResponse, cpr::Error error);
+
+        // Check that the child shell is writable
+        bool checkShellReady(Command &command, int retryAmount, int secondsToWait);
 };
 
 

--- a/src/Job.h
+++ b/src/Job.h
@@ -41,7 +41,7 @@ class Job
         Job(Debug &debug, command_t &job, string baseUrl, string clientId, string apiToken, bool autoExecute = true);
 
         // Process the commands in the job
-        bool process(bool autoReportResults = true);
+        int process(bool autoReportResults = true);
 
         // Report the results to Bakup
         bool reportResults(int retryCounter, int maxRetry);

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -63,7 +63,7 @@ vector<command_t> Request::parseBakupResponse(string &jsonString)
     if(!bakupResponse.Parse(jsonString.c_str()).HasParseError())
     {
         // For each job command in the json object
-        for (auto& job : bakupResponse.GetArray())
+        for (auto& job : bakupResponse["jobs"].GetArray())
         {
             command_t temp;
             temp.id = job["id"].GetString();

--- a/src/ResponseBuilder.h
+++ b/src/ResponseBuilder.h
@@ -4,7 +4,9 @@
 #define SUCCESS_CODE 0
 #define ERROR_CODE_JOB_FAIL 1
 #define ERROR_CODE_JSON_FAIL 2
-#define ERROR_CODE_SSL_FAIL  3
+#define ERROR_CODE_SSL_FAIL 3
+#define ERROR_CODE_WRITE_PIPE_FAIL 4
+#define ERROR_CODE_READ_PIPE_FAIL 5
 
 #include <rapidjson/document.h>
 #include <rapidjson/writer.h>

--- a/tests/CommandTest.cpp
+++ b/tests/CommandTest.cpp
@@ -7,7 +7,7 @@ class CommandTest : public ::testing::Test
         CommandTest()
         {
             this->commandString = "echo \"Hello World\"";
-            this->commandValue = "Hello World\n";
+            this->commandValue = "Hello World";
         }
 
     public:
@@ -17,13 +17,23 @@ class CommandTest : public ::testing::Test
 
 TEST_F(CommandTest, PipeSuccessfullyOpened)
 {
-    Command command(this->commandString);
-    ASSERT_EQ(command.process(), EXIT_SUCCESS);
+    Debug debug(true, "version");
+    Command command(debug);
+    ASSERT_TRUE(command.setupEnvironment());
 }
 
 TEST_F(CommandTest, CorrectCommandOutput)
 {
-    Command command(this->commandString);
-    command.process();
-    ASSERT_EQ(command.getOutput(), this->commandValue);
+    Debug debug(true, "version");
+    Command command(debug);
+    command.setupEnvironment();
+    ASSERT_EQ(command.runCommand(this->commandString).first, this->commandValue);
+}
+
+TEST_F(CommandTest, GenerateDelimiter)
+{
+    Debug debug(true, "version");
+    Command command(debug);
+    string delimiter = command.generateDelimiter();
+    ASSERT_EQ(delimiter.size(), 128);
 }

--- a/tests/CommandTest.cpp
+++ b/tests/CommandTest.cpp
@@ -22,7 +22,7 @@ TEST_F(CommandTest, PipeSuccessfullyOpened)
     ASSERT_TRUE(command.setupEnvironment());
 }
 
-TEST_F(CommandTest, CorrectCommandOutput)
+TEST_F(CommandTest, CommandSuccessTest)
 {
     Debug debug(true, "version");
     Command command(debug);
@@ -36,4 +36,12 @@ TEST_F(CommandTest, GenerateDelimiter)
     Command command(debug);
     string delimiter = command.generateDelimiter();
     ASSERT_EQ(delimiter.size(), 128);
+}
+
+TEST_F(CommandTest, CommandFailureTest)
+{
+    Debug debug(true, "version");
+    Command command(debug);
+    command.setupEnvironment();
+    ASSERT_GT(command.runCommand("notAValidCommand").second, EXIT_SUCCESS);
 }

--- a/tests/CommandTest.cpp
+++ b/tests/CommandTest.cpp
@@ -22,6 +22,26 @@ TEST_F(CommandTest, PipeSuccessfullyOpened)
     ASSERT_TRUE(command.setupEnvironment());
 }
 
+TEST_F(CommandTest, PipeFailsOnInvalidShell)
+{
+    Debug debug(true, "version");
+
+    // Pass an invalid shell that crashes child
+    Command command(debug, "ABadShell");
+
+    ASSERT_FALSE(command.setupEnvironment());
+}
+
+TEST_F(CommandTest, PipeFailsOnBadShell)
+{
+    Debug debug(true, "version");
+
+    // Pass an invalid shell that doesn't crash the child
+    Command command(debug, "/bin/touch");
+
+    ASSERT_FALSE(command.setupEnvironment());
+}
+
 TEST_F(CommandTest, CommandSuccessTest)
 {
     Debug debug(true, "version");

--- a/tests/JobTest.cpp
+++ b/tests/JobTest.cpp
@@ -33,7 +33,7 @@ TEST_F(JobTest, ProcessTest)
 
     // Start the job process
     Job jobObj(debug, job, agent.getBaseURL(), agent.getClientId(), agent.getApiToken(), false);
-    ASSERT_EQ(jobObj.process(false), 0);
+    ASSERT_EQ(jobObj.process(false), EXIT_SUCCESS);
 }
 
 TEST_F(JobTest, FailProcessTest)
@@ -49,7 +49,7 @@ TEST_F(JobTest, FailProcessTest)
 
     // Start the job process
     Job jobObj(debug, job, agent.getBaseURL(), agent.getClientId(), agent.getApiToken(), false);
-    ASSERT_GT(jobObj.process(false), 0);
+    ASSERT_GT(jobObj.process(false), EXIT_SUCCESS);
 }
 
 TEST_F(JobTest, HandleErrors)
@@ -68,4 +68,21 @@ TEST_F(JobTest, HandleErrors)
     cpr::Error error = cpr::Error();
     string httpError = "HTTP ERROR";
     ASSERT_TRUE(jobObj.handleError(httpError, error));
+}
+
+TEST_F(JobTest, CheckShellReady)
+{
+    // Create the command struct
+    command_t job;
+    job.id = "1";
+    job.targetExecutionTime = time(NULL);
+    job.commands.emplace_back("ls");
+
+    // Construct the debug library for output
+    Debug debug(true, agent.getAgentVersion());
+
+    Command command(debug);
+    command.setupEnvironment();
+    Job jobObj(debug, job, agent.getBaseURL(), agent.getClientId(), agent.getApiToken(), false);
+    ASSERT_TRUE(jobObj.checkShellReady(command, 1, 3));
 }

--- a/tests/JobTest.cpp
+++ b/tests/JobTest.cpp
@@ -69,38 +69,3 @@ TEST_F(JobTest, HandleErrors)
     string httpError = "HTTP ERROR";
     ASSERT_TRUE(jobObj.handleError(httpError, error));
 }
-
-TEST_F(JobTest, CheckShellReady)
-{
-    // Create the command struct
-    command_t job;
-    job.id = "1";
-    job.targetExecutionTime = time(NULL);
-    job.commands.emplace_back("ls");
-
-    // Construct the debug library for output
-    Debug debug(true, agent.getAgentVersion());
-
-    Command command(debug);
-    command.setupEnvironment();
-    Job jobObj(debug, job, agent.getBaseURL(), agent.getClientId(), agent.getApiToken(), false);
-    ASSERT_TRUE(jobObj.checkShellReady(command, 1, 3));
-}
-
-TEST_F(JobTest, CheckShellFails)
-{
-    // Create the command struct
-    command_t job;
-    job.id = "1";
-    job.targetExecutionTime = time(NULL);
-    job.commands.emplace_back("ls");
-
-    // Construct the debug library for output
-    Debug debug(true, agent.getAgentVersion());
-
-    Job jobObj(debug, job, agent.getBaseURL(), agent.getClientId(), agent.getApiToken(), false);
-
-    string invalidShell = "/bin/touch";
-    Command command(debug, invalidShell);
-    ASSERT_FALSE(command.setupEnvironment("notAValidCommand"));
-}

--- a/tests/JobTest.cpp
+++ b/tests/JobTest.cpp
@@ -86,3 +86,21 @@ TEST_F(JobTest, CheckShellReady)
     Job jobObj(debug, job, agent.getBaseURL(), agent.getClientId(), agent.getApiToken(), false);
     ASSERT_TRUE(jobObj.checkShellReady(command, 1, 3));
 }
+
+TEST_F(JobTest, CheckShellFails)
+{
+    // Create the command struct
+    command_t job;
+    job.id = "1";
+    job.targetExecutionTime = time(NULL);
+    job.commands.emplace_back("ls");
+
+    // Construct the debug library for output
+    Debug debug(true, agent.getAgentVersion());
+
+    Job jobObj(debug, job, agent.getBaseURL(), agent.getClientId(), agent.getApiToken(), false);
+
+    string invalidShell = "/bin/touch";
+    Command command(debug, invalidShell);
+    ASSERT_FALSE(command.setupEnvironment("notAValidCommand"));
+}


### PR DESCRIPTION
Command class now forks a child of itself whose image is then replaced with an image that is running a bash shell. Two previously created pipes are then linked to it for reading and writing. This enables us to be able to set bash variables for a job, allowing for more efficient processing.