### PR TITLE
Include the type of job in the job response

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,10 @@ touch /etc/opt/bakupagent/API_TOKEN
 echo "$API_TOKEN" | tee /etc/opt/bakupagent/API_TOKEN > /dev/null
 chown "$USER_NAME" /etc/opt/bakupagent/API_TOKEN
 
+# Set permissions of main directory
+echo "Setting permissions..."
+chown "$USER_NAME" /etc/opt/bakupagent/
+
 # Create the service file to manage the service
 echo "Making service file for systemd..."
 echo "[Unit]

--- a/src/Job.cpp
+++ b/src/Job.cpp
@@ -28,7 +28,8 @@ int Job::process(bool autoReportResults, string shell)
         // Build error response and send to Bakup.io
         ResponseBuilder responseBuilder;
         responseBuilder.addSendAttempt(1);
-        responseBuilder.addJobId(job.id);
+        responseBuilder.addJobId(this->job.id);
+        responseBuilder.addJobType(this->job.jobType);
         responseBuilder.addErrorCode(ERROR_CODE_JOB_FAIL);
         responseBuilder.addErrorMessage("Could not open a child process to run the job");
         this->jobOutput = responseBuilder.build();
@@ -63,7 +64,10 @@ int Job::process(bool autoReportResults, string shell)
         responseBuilder.addSendAttempt(1);
 
         // Add the Job ID
-        responseBuilder.addJobId(job.id);
+        responseBuilder.addJobId(this->job.id);
+
+        // Add the job type
+        responseBuilder.addJobType(this->job.jobType);
 
         // Hold all the command's output in this vector
         vector<commandOutput> commandsOutput;

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -67,6 +67,7 @@ vector<command_t> Request::parseBakupResponse(string &jsonString)
         {
             command_t temp;
             temp.id = job["id"].GetString();
+            temp.jobType = job["job_type"].GetString();
 
             // Check for a target execution time
             if(job.HasMember("target_execution_time"))

--- a/src/Request.h
+++ b/src/Request.h
@@ -18,6 +18,7 @@ using namespace rapidjson;
 struct command_t
 {
     string id = "";
+    string jobType = "";
     int targetExecutionTime = 0;
     vector<string> commands;
     bool refreshAgentCredentials = false;

--- a/src/ResponseBuilder.cpp
+++ b/src/ResponseBuilder.cpp
@@ -70,3 +70,9 @@ void ResponseBuilder::addJobId(string id)
     this->writer->Key("id");
     this->writer->String(id.c_str());
 }
+
+void ResponseBuilder::addJobType(string jobType)
+{
+    this->writer->Key("job_type");
+    this->writer->String(jobType.c_str());
+}

--- a/src/ResponseBuilder.h
+++ b/src/ResponseBuilder.h
@@ -52,6 +52,9 @@ class ResponseBuilder
 
         // Add job ID
         void addJobId(string id);
+
+        // Add the job type
+        void addJobType(string jobType);
 };
 
 

--- a/tests/ResponseBuilderTest.cpp
+++ b/tests/ResponseBuilderTest.cpp
@@ -69,3 +69,10 @@ TEST_F(ResponseBuilderTest, AddID)
     responseBuilder.addJobId("test_id");
     ASSERT_EQ(responseBuilder.build(), "{\"id\":\"test_id\"}");
 }
+
+TEST_F(ResponseBuilderTest, AddJobType)
+{
+    ResponseBuilder responseBuilder;
+    responseBuilder.addJobType("test_job_type");
+    ASSERT_EQ(responseBuilder.build(), "{\"job_type\":\"test_job_type\"}");
+}


### PR DESCRIPTION
The install script was also changed to add a command to change the ownership of the install directory so that the user that runs the agent can create backups