### PR TITLE
Separate 'clean up' commands from main commands to ensure they always execute

### DIFF
--- a/src/Agent.cpp
+++ b/src/Agent.cpp
@@ -126,6 +126,11 @@ bool Agent::getJob(Debug &debug, int retryCounter, int retryMaxCount)
                         toPrint.append(command + ", ");
                     }
 
+                    for(const string &command: jobStruct.cleanUpCommands)
+                    {
+                        toPrint.append(command + ", ");
+                    }
+
                     // Print out command string without last comma
                     debug.info(toPrint.substr(0, toPrint.size()-2));
                 }

--- a/src/Agent.cpp
+++ b/src/Agent.cpp
@@ -126,6 +126,7 @@ bool Agent::getJob(Debug &debug, int retryCounter, int retryMaxCount)
                         toPrint.append(command + ", ");
                     }
 
+                    // Store the clean up commands in the toPrint string for printing
                     for(const string &command: jobStruct.cleanUpCommands)
                     {
                         toPrint.append(command + ", ");

--- a/src/Job.cpp
+++ b/src/Job.cpp
@@ -121,6 +121,11 @@ int Job::process(bool autoReportResults, string shell)
         // Check if the clean up commands array is empty or not
         if(!empty(this->job.cleanUpCommands))
         {
+            /*
+             * Loop through the clean up commands. For each command, it is executed and the output is stored
+             * in the main output struct. If a command fails, it will keep running to make sure everything
+             * is cleaned up.
+             */
             for(int i = 0; i < this->job.cleanUpCommands.size(); i++)
             {
                 // Store this clean up commands output

--- a/src/Job.h
+++ b/src/Job.h
@@ -12,6 +12,9 @@
 #include <rapidjson/writer.h>
 #include <rapidjson/stringbuffer.h>
 #include <curl/curl.h>
+#ifdef TESTING
+#include <gtest/gtest.h>
+#endif
 
 using namespace std;
 
@@ -33,10 +36,15 @@ class Job
         // Hold the authentication token
         string apiToken;
 
-        // Store the job's output
-        string jobOutput;
+#ifdef TESTING
+        // Friend class for testing FailProcessFailCleanUpProcessTest
+        FRIEND_TEST(JobTest, FailProcessFailCleanUpProcessTest);
+#endif
 
-    public:
+        protected:
+            // Store the job's output
+            string jobOutput;
+public:
         // Constructor that must be given a reference to debug object and the job to be done
         Job(Debug &debug, command_t &job, string baseUrl, string clientId, string apiToken, bool autoExecute = true);
 

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -80,13 +80,13 @@ vector<command_t> Request::parseBakupResponse(string &jsonString)
             }
 
             // Get the jobs
-            for(auto& command : job["job_commands"].GetArray())
+            for(auto &command : job["job_commands"].GetArray())
             {
                 temp.commands.emplace_back(command.GetString());
             }
 
             // Get the clean up jobs
-            for(auto& command : job["clean_up_commands"].GetArray())
+            for(auto &command : job["clean_up_commands"].GetArray())
             {
                 temp.cleanUpCommands.emplace_back(command.GetString());
             }

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -85,12 +85,17 @@ vector<command_t> Request::parseBakupResponse(string &jsonString)
                 temp.commands.emplace_back(command.GetString());
             }
 
+            // Get the clean up jobs
+            for(auto& command : job["clean_up_commands"].GetArray())
+            {
+                temp.cleanUpCommands.emplace_back(command.GetString());
+            }
+
             // Check for refresh agent credentials setting
             if(job.HasMember("refresh_agent_credentials"))
             {
                 temp.refreshAgentCredentials = job["refresh_agent_credentials"].GetBool();
             }
-
 
             // Add it to the returned vector
             commands.emplace_back(temp);

--- a/src/Request.h
+++ b/src/Request.h
@@ -21,6 +21,7 @@ struct command_t
     string jobType = "";
     int targetExecutionTime = 0;
     vector<string> commands;
+    vector<string> cleanUpCommands;
     bool refreshAgentCredentials = false;
 };
 

--- a/src/ResponseBuilder.cpp
+++ b/src/ResponseBuilder.cpp
@@ -15,16 +15,24 @@ string ResponseBuilder::build()
     return std::string(this->json.GetString());
 }
 
-void ResponseBuilder::addErrorCode(int errorCode)
+void ResponseBuilder::addErrorCode(int errorCode, bool checkError)
 {
-    this->writer->Key("error_code");
-    this->writer->Int(errorCode);
+    if(checkError && !this->errorSet || !checkError)
+    {
+        this->writer->Key("error_code");
+        this->writer->Int(errorCode);
+        this->errorSet = true;
+    }
 }
 
-void ResponseBuilder::addErrorMessage(string errorMessage)
+void ResponseBuilder::addErrorMessage(string errorMessage, bool checkError)
 {
-    this->writer->Key("error_message");
-    this->writer->String(errorMessage.c_str());
+    if(checkError && !this->errorSet || !checkError)
+    {
+        this->writer->Key("error_message");
+        this->writer->String(errorMessage.c_str());
+        this->errorSet = true;
+    }
 }
 
 void ResponseBuilder::addSendAttempt(int sendAttempt)

--- a/src/ResponseBuilder.h
+++ b/src/ResponseBuilder.h
@@ -32,17 +32,20 @@ class ResponseBuilder
         // Store a writer object for use
         rapidjson::Writer<rapidjson::StringBuffer> *writer = new rapidjson::Writer<rapidjson::StringBuffer>(this->json);
 
+        // Has an error already been set?
+        bool errorSet = false;
+
     public:
         ResponseBuilder();
 
         // Finish the JSON object and return string
         string build();
 
-        // Add an error code
-        void addErrorCode(int errorCode);
+        // Add an error code, if checkError is true, it will check to see if an error has already been set
+        void addErrorCode(int errorCode, bool checkError = false);
 
-        // Add an error message
-        void addErrorMessage(string errorMessage);
+        // Add an error message, if checkError is true, it will check to see if an error has already been set
+        void addErrorMessage(string errorMessage, bool checkError = false);
 
         // Add a send attempt int
         void addSendAttempt(int sendAttempt);


### PR DESCRIPTION
The 'clean up' commands will be ran regardless of the exit status of the main commands to ensure that files are not left over on servers