### PR TITLE
Edit Job parent process to ensure that bash child processes are not left as zombies in process table

### DIFF
--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -174,6 +174,7 @@ pid_t Command::getChildPid()
 
 void Command::killChild()
 {
+    // Check that the child was started correctly and that a pid was set
     if(this->pid > -1)
     {
         // Kill the child

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -2,15 +2,6 @@
 
 Command::Command(Debug &debug, string shell) : debug(ref(debug)), shell(std::move(shell))  {}
 
-Command::~Command()
-{
-    if(this->pid > -1)
-    {
-        // Kill the child upon destruction
-        kill(this->pid, SIGKILL);
-    }
-}
-
 string Command::generateDelimiter()
 {
     thread_local std::mt19937 prng(std::random_device{}());
@@ -174,4 +165,18 @@ std::pair<string, exit_status_t> Command::runCommand(string cmd)
 
 bool Command::setShell(string &shell) {
     this->shell = shell;
+}
+
+pid_t Command::getChildPid()
+{
+    return this->pid;
+}
+
+void Command::killChild()
+{
+    if(this->pid > -1)
+    {
+        // Kill the child
+        kill(this->pid, SIGKILL);
+    }
 }

--- a/src/Command.h
+++ b/src/Command.h
@@ -52,9 +52,6 @@ class Command
         // Constructor
         Command(Debug &debug, string shell = "/bin/bash");
 
-        // Destructor
-        ~Command();
-
         // Generate delimiter strings to append to command to know when they're finished
         string generateDelimiter();
 
@@ -66,6 +63,12 @@ class Command
 
         // Setter for shell variable
         bool setShell(string &shell);
+
+        // Getter for the child pid
+        pid_t getChildPid();
+
+        // Run SIGKILL on child process
+        void killChild();
 };
 
 #endif //BAKUP_AGENT_COMMAND_H

--- a/src/Job.cpp
+++ b/src/Job.cpp
@@ -43,6 +43,7 @@ int Job::process(bool autoReportResults, string shell)
         // Kill the bash child
         command.killChild();
 
+        // Wait for the child's status to change and detach from it
         int childExitStatus;
         waitpid(command.getChildPid(), &childExitStatus, 0);
 
@@ -208,6 +209,7 @@ int Job::process(bool autoReportResults, string shell)
     // Kill the bash child
     command.killChild();
 
+    // Wait for the child's status to change and detach from it
     int childExitStatus;
     waitpid(command.getChildPid(), &childExitStatus, 0);
 

--- a/src/Job.cpp
+++ b/src/Job.cpp
@@ -41,7 +41,10 @@ int Job::process(bool autoReportResults, string shell)
         this->reportResults(1, 5);
 
         // Kill the bash child
-        command.~Command();
+        command.killChild();
+
+        int childExitStatus;
+        waitpid(command.getChildPid(), &childExitStatus, 0);
 
         return exitStatus;
     }
@@ -203,7 +206,10 @@ int Job::process(bool autoReportResults, string shell)
     }
 
     // Kill the bash child
-    command.~Command();
+    command.killChild();
+
+    int childExitStatus;
+    waitpid(command.getChildPid(), &childExitStatus, 0);
 
     return exitStatus;
 }

--- a/src/Job.h
+++ b/src/Job.h
@@ -11,6 +11,7 @@
 #include <rapidjson/document.h>
 #include <rapidjson/writer.h>
 #include <rapidjson/stringbuffer.h>
+#include <sys/wait.h>
 #include <curl/curl.h>
 #ifdef TESTING
 #include <gtest/gtest.h>


### PR DESCRIPTION
The Job parent process now uses a waitpid to check for the child process being killed so that it is not left as a zombie process