### PR TITLE
BAK-75 Add env vars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,18 @@ cmake_minimum_required(VERSION 3.7)
 PROJECT(Bakup_Agent)
 set(BINARY ${CMAKE_PROJECT_NAME})
 
+set(ENV "prod" CACHE STRING "Set the environment to build for")
+
+if(ENV STREQUAL "dev")
+    add_definitions(-DBAKUP_HOST="localhost")
+    add_definitions(-DBAKUP_INSECURE_PROTOCOL="http://")
+    add_definitions(-DBAKUP_SECURE_PROTOCOL="http://")
+elseif(ENV STREQUAL "prod")
+    add_definitions(-DBAKUP_HOST="bakup.io")
+    add_definitions(-DBAKUP_INSECURE_PROTOCOL="http://")
+    add_definitions(-DBAKUP_SECURE_PROTOCOL="https://")
+endif()
+
 # Set DEBUG to false if it is not passed as a parameter
 set(DEBUG FALSE CACHE BOOL "")
 message("DEBUG MODE: " ${DEBUG})

--- a/src/Agent.h
+++ b/src/Agent.h
@@ -16,6 +16,7 @@
 #include <SSLChecker.h>
 #include <curl/curl.h>
 #include <cpr/cpr.h>
+#include <Environment.h>
 #ifdef TESTING
 #include <gtest/gtest.h>
 #endif
@@ -25,6 +26,9 @@ using namespace std;
 class Agent
 {
     private:
+        // Get environment variables
+        Environment env = Environment();
+
         // Folder for configuration files
         const string configDirectory = "/etc/opt/bakupagent";
 
@@ -53,7 +57,7 @@ class Agent
         string initialisedLocation = configDirectory + "/.INITIALISED";
 
         // Host URL
-        const string host = "bakup.io";
+        const string host = this->env.HOST;
 
         // Base URL
         const string baseUrl = "/api/agent";

--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -1,0 +1,25 @@
+#include <Environment.h>
+
+Environment::Environment()
+{
+    this->HOST = this->getEnv(BAKUP_HOST, "bakup.io");
+    this->INSECURE_PROTOCOL = this->getEnv(BAKUP_INSECURE_PROTOCOL, "http://");
+    this->SECURE_PROTOCOL = this->getEnv(BAKUP_SECURE_PROTOCOL, "https://");
+}
+
+Environment::Environment(const Environment &environment)
+{
+    this->HOST = environment.HOST;
+    this->INSECURE_PROTOCOL = environment.INSECURE_PROTOCOL;
+    this->SECURE_PROTOCOL = environment.SECURE_PROTOCOL;
+}
+
+std::string Environment::getEnv(string env, string defaultValue)
+{
+    if (env == "")
+    {
+        return defaultValue;
+    }
+
+    return env;
+}

--- a/src/Environment.h
+++ b/src/Environment.h
@@ -1,0 +1,39 @@
+#ifndef BAKUP_AGENT_ENVIRONMENT_H
+#define BAKUP_AGENT_ENVIRONMENT_H
+
+#ifndef BAKUP_HOST
+    #define BAKUP_HOST ""
+#endif
+
+#ifndef BAKUP_INSECURE_PROTOCOL
+    #define BAKUP_INSECURE_PROTOCOL ""
+#endif
+
+#ifndef BAKUP_SECURE_PROTOCOL
+    #define BAKUP_SECURE_PROTOCOL ""
+#endif
+
+#include <string>
+
+using namespace std;
+
+class Environment
+{
+    public:
+        // Constructor
+        Environment();
+
+        // Copy constructor
+        Environment(const Environment &environment);
+
+        // Function returns environment variable or default value if empty
+        string getEnv(string env, string defaultValue);
+
+        string HOST;
+
+        string INSECURE_PROTOCOL;
+
+        string SECURE_PROTOCOL;
+};
+
+#endif //BAKUP_AGENT_ENVIRONMENT_H

--- a/src/Request.h
+++ b/src/Request.h
@@ -11,6 +11,7 @@
 #include <Debug.h>
 #include <ResponseBuilder.h>
 #include <RCloneVersionChecker.h>
+#include <Environment.h>
 
 using namespace std;
 using namespace rapidjson;
@@ -29,6 +30,9 @@ struct command_t
 class Request
 {
     private:
+        // Get environment variables
+        Environment env = Environment();
+
         // Client Id
         const string clientId;
 
@@ -36,10 +40,10 @@ class Request
         const string apiToken;
 
         // Insecure protocol
-        const string insecureProtocol = "http://";
+        const string insecureProtocol = this->env.INSECURE_PROTOCOL;
 
         // Secure protocol
-        const string secureProtocol = "https://";
+        const string secureProtocol = this->env.SECURE_PROTOCOL;
 
         // URL to access
         const string baseUrl;

--- a/src/Response.h
+++ b/src/Response.h
@@ -9,6 +9,7 @@
 #include <rapidjson/writer.h>
 #include <rapidjson/stringbuffer.h>
 #include <RCloneVersionChecker.h>
+#include <Environment.h>
 
 using namespace std;
 using namespace rapidjson;
@@ -16,6 +17,9 @@ using namespace rapidjson;
 class Response
 {
     private:
+        // Get environment variables
+        Environment env = Environment();
+
         // Client Id
         const string clientId;
 
@@ -23,10 +27,10 @@ class Response
         const string apiToken;
 
         // Insecure protocol
-        const string insecureProtocol = "http://";
+        const string insecureProtocol = this->env.INSECURE_PROTOCOL;
 
         // Secure protocol
-        const string secureProtocol = "https://";
+        const string secureProtocol = this->env.SECURE_PROTOCOL;
 
         // URL to access
         const string baseUrl;


### PR DESCRIPTION
Instead of having to change the agent's code to use different constant variables, we can now add them to the Environment files and pass them in at compile time.